### PR TITLE
better onscreen order

### DIFF
--- a/ingredients/plan.json
+++ b/ingredients/plan.json
@@ -19,6 +19,11 @@
     },
     {
       "type": "paraField",
+      "name": "sectionNumber",
+      "paraTag": "ms2"
+    },
+    {
+      "type": "paraField",
       "name": "themeTitle",
       "paraTag": "is2"
     },
@@ -49,11 +54,6 @@
     },
     {
       "type": "paraField",
-      "name": "scriptureTitle",
-      "paraTag": "is2"
-    },
-    {
-      "type": "paraField",
       "name": "principleTitle",
       "paraTag": "is2"
     },
@@ -69,8 +69,8 @@
     },
     {
       "type": "paraField",
-      "name": "sectionNumber",
-      "paraTag": "ms2"
+      "name": "scriptureTitle",
+      "paraTag": "is2"
     },
     {
       "type": "scripture"


### PR DESCRIPTION
This addresses the oncreen order, putting "Story #" at the top, just under the Title.  And then moving "The Story" (scriptureTitle) down to just above the scripture. They were meant to go together anyway.  The "scritpureTitle" was up where the scripture story was in the original printed concept.

<img width="246" height="505" alt="image" src="https://github.com/user-attachments/assets/a54e9b60-fe12-4a02-be72-11c6317ff36d" />
