### PR TITLE
temporary abridgment fix

### DIFF
--- a/ingredients/plan.json
+++ b/ingredients/plan.json
@@ -712,9 +712,9 @@
         "reference": "Genesis 37; 39:22 - 40:4; 45:1-11, 25-28",
         "principle": "God honors those who follow Him and turns every evil intent to a good outcome.",
         "principleMore": "God chose Joseph from among his brothers to rule over them and to provide for his father’s house during a time of famine. When his brothers’ evil actions caused a series of hardships, Joseph responded to each one by honoring God and living a life of righteousness and integrity. God used the evil intent of others and turned it for the good of His servant Joseph.",
-        "bridge_joseph_potiphar": "Joseph served faithfully in Potiphar's house but was betrayed by Potiphar's wife and sent to jail.",
-        "bridge_joseph_dreams": "Both of these prisoners came to know that Joseph was able to interpret dreams. After they had been in custody for some time, one was killed and the other, a cup-bearer, was promoted to Pharaoh’s court. Two years later, the cup-bearer remembered Joseph and told Pharaoh that Joseph would be able to interpret his troubling dream. God gave Joseph the ability to interpret Pharaoh’s dream warning of seven years of famine. Pharaoh rewarded Joseph for interpreting the dream by making him second in command over all the land.",
-        "bridge_joseph_famine": "When famine came, just as the dream foretold, the brothers of Joseph came to Egypt looking for food. Joseph provided them food, sent them back to their father, but kept one brother in Egypt to ensure their return."
+        "bridge_joseph_potiphar": "[ ... Joseph served faithfully in Potiphar's house but was betrayed by Potiphar's wife and sent to jail. ... ]",
+        "bridge_joseph_dreams": "[ ... Both of these prisoners came to know that Joseph was able to interpret dreams. After they had been in custody for some time, one was killed and the other, a cup-bearer, was promoted to Pharaoh’s court. Two years later, the cup-bearer remembered Joseph and told Pharaoh that Joseph would be able to interpret his troubling dream. God gave Joseph the ability to interpret Pharaoh’s dream warning of seven years of famine. Pharaoh rewarded Joseph for interpreting the dream by making him second in command over all the land. ... ]",
+        "bridge_joseph_famine": "[ ... When famine came, just as the dream foretold, the brothers of Joseph came to Egypt looking for food. Joseph provided them food, sent them back to their father, but kept one brother in Egypt to ensure their return. ... ]"
       },
       "paragraphs": [
         {
@@ -1007,7 +1007,7 @@
         "introBody": "God sent nine plagues to Pharaoh and the Egyptian people in hopes that they would repent and allow the children of Israel to return to the Promised Land. But Pharaoh’s heart was stubborn, and he refused to release Moses and his people.",
         "principle": "God rescues His people from evil.",
         "principleMore": "When Pharaoh, the evil leader of Egypt, refused to let the Israelites return to their Promised Land, God sent plagues, hardship, and disaster on their land. Eventually, the Israelites were delivered by God out of the hands of Egypt by crossing the Red Sea on dry land.",
-        "bridge_leaving_egypt": "That night, 600,000 men, plus all the women and children, left on foot. God led them along a route through the wilderness toward the Red Sea, and the Israelites left Egypt like a marching army. The LORD guided them by a pillar of cloud during the day and a pillar of fire at night. That way, they could travel whether it was day or night. And the LORD did not remove the pillar of cloud or fire from their sight."
+        "bridge_leaving_egypt": "[ ... That night, 600,000 men, plus all the women and children, left on foot. God led them along a route through the wilderness toward the Red Sea, and the Israelites left Egypt like a marching army. The LORD guided them by a pillar of cloud during the day and a pillar of fire at night. That way, they could travel whether it was day or night. And the LORD did not remove the pillar of cloud or fire from their sight. ... ]"
       },
       "paragraphs": [
         {


### PR DESCRIPTION
[ ... This uses this approach ... ]

The only twist is that in the middle of RTL scripture text, the opening [ ... becomes RTL because there is no LTR character preceding it to tie it to LTR.  But hey, the abridgement already stands out in that context quite well already!

(This is the exact same thing as the issue with rendering usfm code in RTL, because the opening \ takes becomes RTL.)